### PR TITLE
update extendr to 0.7 for CRAN

### DIFF
--- a/src/cargo_vendor_config.toml
+++ b/src/cargo_vendor_config.toml
@@ -1,10 +1,5 @@
 [source.crates-io]
 replace-with = "vendored-sources"
 
-[source."git+https://github.com/extendr/extendr?rev=refs/pull/627/head"]
-git = "https://github.com/extendr/extendr"
-rev = "refs/pull/627/head"
-replace-with = "vendored-sources"
-
 [source.vendored-sources]
 directory = "vendor"

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -66,18 +66,19 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "ctor"
-version = "0.2.4"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f34ba9a9bcb8645379e9de8cb3ecfcf4d1c85ba66d90deb3259206fa5aa193b"
+checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.37",
+ "syn",
 ]
 
 [[package]]
 name = "extendr-api"
-version = "0.4.0"
-source = "git+https://github.com/extendr/extendr?rev=refs/pull/627/head#ab1a319e6916995fc10ea3841ecec1ddaf54c9d0"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0701db497d091675e50bb10ba870999742cd1e9a9d94cf3fb52f3ea9a7629c0"
 dependencies = [
  "extendr-macros",
  "libR-sys",
@@ -87,8 +88,9 @@ dependencies = [
 
 [[package]]
 name = "extendr-engine"
-version = "0.4.0"
-source = "git+https://github.com/extendr/extendr?rev=refs/pull/627/head#ab1a319e6916995fc10ea3841ecec1ddaf54c9d0"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae890e2fffb0973f3c106eabf72a49112022b724a56d34e1511d13b8e9a6039"
 dependencies = [
  "ctor",
  "libR-sys",
@@ -96,12 +98,13 @@ dependencies = [
 
 [[package]]
 name = "extendr-macros"
-version = "0.4.0"
-source = "git+https://github.com/extendr/extendr?rev=refs/pull/627/head#ab1a319e6916995fc10ea3841ecec1ddaf54c9d0"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d6b806beee182ab3e1105c822df137913b894847a13ec29dfbff9abfb6d1d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -138,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "libR-sys"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34aaa68a201f71eab5df5a67d1326add8aaf029434e939353bcab0534919ff1"
+checksum = "44f2e4b6f402557010b557dd181842168db92da2c0d747bd091bd175941c570d"
 
 [[package]]
 name = "libc"
@@ -195,17 +198,6 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
@@ -242,7 +234,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -264,7 +256,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -348,5 +340,4 @@ dependencies = [
  "chrono",
  "extendr-api",
  "extendr-engine",
- "libR-sys",
 ]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -7,9 +7,8 @@ edition = '2021'
 crate-type = ['staticlib']
 
 [dependencies]
-extendr-api = { package = "extendr-api", git = "https://github.com/extendr/extendr", rev = "refs/pull/627/head" }
+extendr-api = "0.7"
 chrono = "0.4.26"
 
 [dev-dependencies]
-extendr-engine = { package = "extendr-engine", git = "https://github.com/extendr/extendr", rev = "refs/pull/627/head" }
-libR-sys = "0.6.0"
+extendr-engine = "0.7"

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -285,7 +285,7 @@ mod test {
     #[test]
     fn to_date() {
         test! {
-            let x: Robj = r!([18990.0, 18991.0]).set_class(&["Date"]).unwrap();
+            let x: Robj = r!([18990.0, 18991.0]).set_class(&["Date"]).unwrap().clone();
             assert_eq!(rdate::robj2date(x, "x").unwrap(), [Some(NaiveDate::from_ymd_opt(2021, 12, 29).unwrap()), Some(NaiveDate::from_ymd_opt(2021, 12, 30).unwrap())]);
         }
     }

--- a/src/rust/src/rdate.rs
+++ b/src/rust/src/rdate.rs
@@ -71,20 +71,20 @@ impl ToRDate for [NaiveDate] {
 
 impl ToRDate for Vec<Option<f64>> {
     fn to_rdate(&self) -> Robj {
-        r!(self.clone()).set_class(&["Date"]).unwrap()
+        r!(self.clone()).set_class(&["Date"]).unwrap().clone()
     }
 }
 
 impl ToRDate for [f64] {
     fn to_rdate(&self) -> Robj {
-        r!(self).set_class(&["Date"]).unwrap()
+        r!(self).set_class(&["Date"]).unwrap().clone()
     }
 }
 
 impl ToRDate for [i32] {
     fn to_rdate(&self) -> Robj {
         let out: Vec<f64> = self.iter().map(|v| *v as f64).collect();
-        r!(out).set_class(&["Date"]).unwrap()
+        r!(out).set_class(&["Date"]).unwrap().clone()
     }
 }
 
@@ -95,7 +95,7 @@ mod tests {
     fn to_date() {
         test! {
             single_threaded(|| {
-                let r_dates: Robj = r!([18990.0, 18991.0]).set_class(&["Date"]).unwrap();
+                let r_dates: Robj = r!([18990.0, 18991.0]).set_class(&["Date"]).unwrap().clone();
                 let rust_dates = [Some(NaiveDate::from_ymd_opt(2021, 12, 29).unwrap()), Some(NaiveDate::from_ymd_opt(2021, 12, 30).unwrap())];
                 assert_eq!(robj2date(r_dates.clone(), "r_dates").unwrap(), rust_dates);
                 assert_eq!(rust_dates.to_rdate(), r_dates);


### PR DESCRIPTION
- Update `extendr` packages to `0.7`. 
- I removed the explicit dependency on `libR-sys` as that should not be needed, and if it were, we probably fixed the bugs with that.