### PR TITLE
Add `xz` to system requirements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Convert 'YMD' format number or string to Date efficiently, using Ru
 License: MIT + file LICENSE
 URL: https://shrektan.github.io/ymd/, https://github.com/shrektan/ymd
 BugReports: https://github.com/shrektan/ymd/issues
-SystemRequirements: Cargo (Rust's package manager), rustc
+SystemRequirements: Cargo (Rust's package manager), rustc, xz
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2


### PR DESCRIPTION
So that some package managers will auto-install the dependency.

Without it, installation errors with

```
using C compiler: 'gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0'
rm -Rf ymd.so entrypoint.o ./rust/.cargo ./rust/target/release/libymd.a
ccache gcc -I"/opt/R/4.4.1/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -g -O2  -Wall -pedantic -fdiagnostics-color=always -c entrypoint.c -o entrypoint.o
# vendoring (Note: to avoid NOTE of "Found the following hidden files and
# directories", .cargo needs to be created here)
if [ "yes" = "yes" ]; then \
  /usr/bin/tar --extract --xz -f ./rust/vendor.tar.xz -C ./rust && \
    mkdir -p ./rust/.cargo && \
    cp ./cargo_vendor_config.toml ./rust/.cargo/config.toml; \
fi
tar (child): xz: Cannot exec: No such file or directory
tar (child): Error is not recoverable: exiting now
/usr/bin/tar: Child returned status 2
/usr/bin/tar: Error is not recoverable: exiting now
```